### PR TITLE
Add multiplication dataset builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ python dataset/build_sudoku_dataset.py --output-dir data/sudoku-extreme-1k-aug-1
 
 # Maze
 python dataset/build_maze_dataset.py  # 1000 examples
+# Multiplication
+python dataset/build_mult_digit_mul_dataset.py  # Random multi-digit multiplication
 ```
 
 ### Dataset Visualization
@@ -149,6 +151,14 @@ OMP_NUM_THREADS=8 torchrun --nproc-per-node 8 pretrain.py data_path=data/maze-30
 ```
 
 *Runtime:* ~1 hour
+
+Multiplication:
+
+```bash
+OMP_NUM_THREADS=8 torchrun --nproc-per-node 8 pretrain.py data_path=data/mult-digit-mul
+```
+
+*Runtime:* varies with dataset size
 
 ### Full Sudoku-Hard
 

--- a/dataset/build_mult_digit_mul_dataset.py
+++ b/dataset/build_mult_digit_mul_dataset.py
@@ -1,0 +1,122 @@
+"""Utility to generate a multiplication dataset for HRM."""
+
+import os
+import json
+import numpy as np
+from argdantic import ArgParser
+from pydantic import BaseModel
+from tqdm import tqdm
+
+from common import PuzzleDatasetMetadata
+
+cli = ArgParser()
+
+class DataProcessConfig(BaseModel):
+    """Configuration options for dataset generation."""
+    output_dir: str = "data/mult-digit-mul"
+    num_train: int = 10000
+    num_test: int = 1000
+    max_digits: int = 3
+
+
+def number_to_row(number: int, width: int) -> np.ndarray:
+    """Return a row of digits for ``number`` padded to ``width`` with zeros."""
+    digits = str(number).rjust(width, "0")
+    return np.frombuffer(digits.encode(), dtype=np.uint8) - ord("0")
+
+
+def generate_dataset(split: str, num_examples: int, cfg: DataProcessConfig):
+    """Generate one split of the dataset."""
+
+    rng = np.random.default_rng()
+    width = cfg.max_digits * 2
+
+    # Storage for all examples in this split
+    results = {k: [] for k in ["inputs", "labels", "puzzle_identifiers", "puzzle_indices", "group_indices"]}
+    # "puzzle_id" and "example_id" track dataset indexing for HRM's loader
+    puzzle_id = 0
+    example_id = 0
+
+    results["puzzle_indices"].append(0)
+    results["group_indices"].append(0)
+
+    for _ in tqdm(range(num_examples)):
+        # Generate a new multiplication example
+        # Randomly choose digit lengths for the two operands
+        digits_a = rng.integers(1, cfg.max_digits + 1)
+        digits_b = rng.integers(1, cfg.max_digits + 1)
+
+        # Sample numbers of the chosen length (no leading zeros)
+        a = rng.integers(10 ** (digits_a - 1), 10 ** digits_a)
+        b = rng.integers(10 ** (digits_b - 1), 10 ** digits_b)
+
+        product = a * b
+
+        # Convert numbers to fixed-width digit rows
+        row_a = number_to_row(a, width)
+        row_b = number_to_row(b, width)
+        row_c = number_to_row(product, width)
+
+        # Third row is blank in the input and filled with the product in labels
+        inp = np.vstack([row_a, row_b, np.zeros_like(row_c)])
+        out = np.vstack([row_a, row_b, row_c])
+
+        results["inputs"].append(inp)
+        results["labels"].append(out)
+        example_id += 1
+        puzzle_id += 1
+
+        results["puzzle_indices"].append(example_id)
+        results["puzzle_identifiers"].append(0)
+        results["group_indices"].append(puzzle_id)
+
+    def _seq_to_numpy(seq):
+        """Flatten list of grids to token IDs (1..10)."""
+        arr = np.concatenate(seq).reshape(len(seq), -1)
+        assert np.all((arr >= 0) & (arr <= 9))
+        # Shift by one so 0 becomes 1 and reserve 0 for padding
+        return arr + 1
+
+    results = {
+        "inputs": _seq_to_numpy(results["inputs"]),
+        "labels": _seq_to_numpy(results["labels"]),
+        "group_indices": np.array(results["group_indices"], dtype=np.int32),
+        "puzzle_indices": np.array(results["puzzle_indices"], dtype=np.int32),
+        "puzzle_identifiers": np.array(results["puzzle_identifiers"], dtype=np.int32),
+    }
+
+    # Metadata describing the dataset for the HRM loader
+    metadata = PuzzleDatasetMetadata(
+        seq_len=width * 3,
+        vocab_size=11,  # PAD + digits 0-9
+        pad_id=0,
+        ignore_label_id=0,
+        blank_identifier_id=0,
+        num_puzzle_identifiers=1,
+        total_groups=len(results["group_indices"]) - 1,
+        mean_puzzle_examples=1,
+        sets=["all"],
+    )
+
+    save_dir = os.path.join(cfg.output_dir, split)
+    os.makedirs(save_dir, exist_ok=True)
+    with open(os.path.join(save_dir, "dataset.json"), "w") as f:
+        json.dump(metadata.model_dump(), f)
+    # Each field is stored as a separate .npy file
+    for k, v in results.items():
+        np.save(os.path.join(save_dir, f"all__{k}.npy"), v)
+
+
+@cli.command(singleton=True)
+def preprocess_data(config: DataProcessConfig):
+    """Entry point used from the command line."""
+
+    generate_dataset("train", config.num_train, config)
+    generate_dataset("test", config.num_test, config)
+    # Only a single identifier is used ("<blank>") for visualization
+    with open(os.path.join(config.output_dir, "identifiers.json"), "w") as f:
+        json.dump(["<blank>"], f)
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary
- create dataset/build_mult_digit_mul_dataset.py to generate random multiplication tasks
- document dataset generation and training usage in README

## Testing
- `python dataset/build_mult_digit_mul_dataset.py --help`
- `python dataset/build_mult_digit_mul_dataset.py --num-train 10 --num-test 5 --output-dir data/test-mul`
- `python -m py_compile dataset/build_mult_digit_mul_dataset.py`


------
https://chatgpt.com/codex/tasks/task_e_688a07ed5bac832696671242c5cd2e15