### PR TITLE
Handle missing FlashAttention gracefully

### DIFF
--- a/models/layers.py
+++ b/models/layers.py
@@ -6,9 +6,14 @@ import torch.nn.functional as F
 
 try:
     from flash_attn_interface import flash_attn_func  # type: ignore[import]
-except ImportError:
-    # Fallback to FlashAttention 2
-    from flash_attn import flash_attn_func  # type: ignore[import]
+except Exception:
+    try:
+        # FlashAttention 2
+        from flash_attn import flash_attn_func  # type: ignore[import]
+    except Exception:
+        # Final fallback using PyTorch attention
+        def flash_attn_func(q, k, v, causal=False):
+            return F.scaled_dot_product_attention(q, k, v, dropout_p=0.0, is_causal=causal)
 
 from models.common import trunc_normal_init_
 


### PR DESCRIPTION
## Summary
- handle ImportError or load errors when importing FlashAttention
- fallback to PyTorch's `scaled_dot_product_attention` when flash-attn is unavailable

## Testing
- `python -m py_compile models/layers.py`
- `python -m py_compile pretrain.py puzzle_dataset.py models/losses.py models/common.py models/sparse_embedding.py utils/functions.py dataset/build_mult_digit_mul_dataset.py dataset/common.py dataset/build_maze_dataset.py dataset/build_arc_dataset.py dataset/build_sudoku_dataset.py evaluate.py`

------
https://chatgpt.com/codex/tasks/task_e_688c801de87483268f84897d191281a8