### PR TITLE
Fix overflow in multiplication dataset generation

### DIFF
--- a/dataset/build_mult_digit_mul_dataset.py
+++ b/dataset/build_mult_digit_mul_dataset.py
@@ -47,9 +47,20 @@ def generate_dataset(split: str, num_examples: int, cfg: DataProcessConfig):
         digits_a = rng.integers(1, cfg.max_digits + 1)
         digits_b = rng.integers(1, cfg.max_digits + 1)
 
-        # Sample numbers of the chosen length (no leading zeros)
-        a = rng.integers(10 ** (digits_a - 1), 10 ** digits_a)
-        b = rng.integers(10 ** (digits_b - 1), 10 ** digits_b)
+        # Sample numbers of the chosen length (no leading zeros).  ``np.random``
+        # is limited to 64-bit integers, so we build the numbers digit-by-digit to
+        # avoid overflow when ``cfg.max_digits`` is large.
+        def sample_number(num_digits: int) -> int:
+            first = rng.integers(1, 10)
+            if num_digits == 1:
+                digits = [first]
+            else:
+                rest = rng.integers(0, 10, size=num_digits - 1)
+                digits = np.concatenate([[first], rest])
+            return int("".join(str(int(d)) for d in digits))
+
+        a = sample_number(digits_a)
+        b = sample_number(digits_b)
 
         product = a * b
 


### PR DESCRIPTION
## Summary
- avoid int64 overflow when generating random numbers in `build_mult_digit_mul_dataset`
- sample digits individually to support operands up to the configured `max_digits`

## Testing
- `python dataset/build_mult_digit_mul_dataset.py --num-train 5 --num-test 3 --max-digits 20 --print-samples 1`


------
https://chatgpt.com/codex/tasks/task_e_68931e38c74c8326a3815813a297b395