### PR TITLE
Handle padding and add digit curriculum for multiplication task

### DIFF
--- a/pretrain.py
+++ b/pretrain.py
@@ -70,6 +70,10 @@ class PretrainConfig(pydantic.BaseModel):
     eval_interval: Optional[int] = None
     eval_save_outputs: List[str] = []
 
+    # Curriculum learning
+    max_digits_schedule: List[int] = []
+    stage_epochs: int = 1
+
 
 @dataclass
 class TrainState:
@@ -82,7 +86,7 @@ class TrainState:
     total_steps: int
 
 
-def create_dataloader(config: PretrainConfig, split: str, rank: int, world_size: int, **kwargs):
+def create_dataloader(config: PretrainConfig, split: str, rank: int, world_size: int, max_digits: Optional[int] = None, **kwargs):
     dataset = PuzzleDataset(PuzzleDatasetConfig(
         seed=config.seed,
 
@@ -90,7 +94,8 @@ def create_dataloader(config: PretrainConfig, split: str, rank: int, world_size:
 
         rank=rank,
         num_replicas=world_size,
-        
+        max_digits=max_digits,
+
         **kwargs
     ), split=split)
     dataloader = DataLoader(
@@ -545,17 +550,16 @@ def launch(hydra_config: DictConfig):
     # Seed RNGs to ensure consistency
     torch.random.manual_seed(config.seed + RANK)
 
-    # Dataset
-    train_epochs_per_iter = config.eval_interval if config.eval_interval is not None else config.epochs
-    total_iters = config.epochs // train_epochs_per_iter
+    # Curriculum setup
+    curriculum = config.max_digits_schedule or [None]
+    stage_metadatas = []
+    for md in curriculum:
+        _, meta = create_dataloader(config, "train", test_set_mode=False, epochs_per_iter=1, global_batch_size=config.global_batch_size, rank=RANK, world_size=WORLD_SIZE, max_digits=md)
+        stage_metadatas.append(meta)
 
-    assert config.epochs % train_epochs_per_iter == 0, "Eval interval must be a divisor of total epochs."
-
-    train_loader, train_metadata = create_dataloader(config, "train", test_set_mode=False, epochs_per_iter=train_epochs_per_iter, global_batch_size=config.global_batch_size, rank=RANK, world_size=WORLD_SIZE)
-    val_loader,  val_metadata  = create_dataloader(config, "test", test_set_mode=True, epochs_per_iter=1, global_batch_size=config.global_batch_size, rank=RANK, world_size=WORLD_SIZE)
-
-    # Train state
-    train_state = init_train_state(config, train_metadata, world_size=WORLD_SIZE)
+    # Train state based on last stage metadata (assumed to have largest seq_len)
+    train_state = init_train_state(config, stage_metadatas[-1], world_size=WORLD_SIZE)
+    train_state.total_steps = sum(int(config.stage_epochs * m.total_groups * m.mean_puzzle_examples / config.global_batch_size) for m in stage_metadatas)
 
     # Progress bar and logger
     progress_bar = None
@@ -566,47 +570,59 @@ def launch(hydra_config: DictConfig):
         wandb.log({"num_params": sum(x.numel() for x in train_state.model.parameters())}, step=0)
         save_code_and_config(config)
 
-    # Training Loop
-    for _iter_id in range(total_iters):
-        print (f"[Rank {RANK}, World Size {WORLD_SIZE}]: Epoch {_iter_id * train_epochs_per_iter}")
+    # Training Loop across curriculum stages
+    completed_epochs = 0
+    for stage_idx, max_digits in enumerate(curriculum):
+        print(f"[Rank {RANK}, World Size {WORLD_SIZE}]: Curriculum stage {stage_idx + 1}/{len(curriculum)} max_digits={max_digits}")
+        train_epochs_per_iter = config.eval_interval if config.eval_interval is not None else config.stage_epochs
+        total_iters = config.stage_epochs // train_epochs_per_iter
+        assert config.stage_epochs % train_epochs_per_iter == 0, "Eval interval must be a divisor of stage epochs."
 
-        ############ Train Iter
-        train_state.model.train()
-        for set_name, batch, global_batch_size in train_loader:
-            metrics = train_batch(config, train_state, batch, global_batch_size, rank=RANK, world_size=WORLD_SIZE)
+        train_loader, _ = create_dataloader(config, "train", test_set_mode=False, epochs_per_iter=train_epochs_per_iter, global_batch_size=config.global_batch_size, rank=RANK, world_size=WORLD_SIZE, max_digits=max_digits)
+        val_loader,  val_metadata  = create_dataloader(config, "test", test_set_mode=True, epochs_per_iter=1, global_batch_size=config.global_batch_size, rank=RANK, world_size=WORLD_SIZE, max_digits=max_digits)
+
+        for _iter_id in range(total_iters):
+            current_epoch = completed_epochs + _iter_id * train_epochs_per_iter
+            print(f"[Rank {RANK}, World Size {WORLD_SIZE}]: Epoch {current_epoch}")
+
+            ############ Train Iter
+            train_state.model.train()
+            for set_name, batch, global_batch_size in train_loader:
+                metrics = train_batch(config, train_state, batch, global_batch_size, rank=RANK, world_size=WORLD_SIZE)
+
+                if RANK == 0 and metrics is not None:
+                    wandb.log(metrics, step=train_state.step)
+                    progress_bar.update(train_state.step - progress_bar.n)  # type: ignore
+
+            ############ Validation
+            train_state.model.eval()
+            metrics, last_hidden, last_tokens = validate(config, train_state, val_loader, val_metadata, rank=RANK, world_size=WORLD_SIZE)
 
             if RANK == 0 and metrics is not None:
                 wandb.log(metrics, step=train_state.step)
-                progress_bar.update(train_state.step - progress_bar.n)  # type: ignore
+                if stage_idx == len(curriculum) - 1 and _iter_id == total_iters - 1:
+                    log_hidden_state_pca(last_hidden, last_tokens, train_state.step)
 
-        ############ Validation
-        train_state.model.eval()
-        metrics, last_hidden, last_tokens = validate(config, train_state, val_loader, val_metadata, rank=RANK, world_size=WORLD_SIZE)
+            if RANK == 0 and current_epoch % 100 == 0:
+                example_set, example_batch, _ = next(iter(val_loader))
+                example_gpu = {k: v.cuda() for k, v in example_batch.items()}
+                with torch.inference_mode(), torch.device("cuda"):
+                    sample_carry = train_state.model.initial_carry(example_gpu)  # type: ignore
+                    while True:
+                        sample_carry, _, _, sample_preds, all_finish = train_state.model(
+                            carry=sample_carry, batch=example_gpu, return_keys=["logits"])
+                        if all_finish:
+                            break
+                pred_tokens = sample_preds["logits"].argmax(dim=-1).cpu()
+                print("Input:\n" + decode_tokens(example_batch["inputs"][0]))
+                print("Correct output:\n" + decode_tokens(example_batch["labels"][0]))
+                print("Model output:\n" + decode_tokens(pred_tokens[0]))
 
-        if RANK == 0 and metrics is not None:
-            wandb.log(metrics, step=train_state.step)
-            if _iter_id == total_iters - 1:
-                log_hidden_state_pca(last_hidden, last_tokens, train_state.step)
+            ############ Checkpointing
+            if RANK == 0 and (config.checkpoint_every_eval or (stage_idx == len(curriculum) - 1 and _iter_id == total_iters - 1)):
+                save_train_state(config, train_state)
 
-        current_epoch = _iter_id * train_epochs_per_iter
-        if RANK == 0 and current_epoch % 100 == 0:
-            example_set, example_batch, _ = next(iter(val_loader))
-            example_gpu = {k: v.cuda() for k, v in example_batch.items()}
-            with torch.inference_mode(), torch.device("cuda"):
-                sample_carry = train_state.model.initial_carry(example_gpu)  # type: ignore
-                while True:
-                    sample_carry, _, _, sample_preds, all_finish = train_state.model(
-                        carry=sample_carry, batch=example_gpu, return_keys=["logits"])
-                    if all_finish:
-                        break
-            pred_tokens = sample_preds["logits"].argmax(dim=-1).cpu()
-            print("Input:\n" + decode_tokens(example_batch["inputs"][0]))
-            print("Correct output:\n" + decode_tokens(example_batch["labels"][0]))
-            print("Model output:\n" + decode_tokens(pred_tokens[0]))
-            
-        ############ Checkpointing
-        if RANK == 0 and (config.checkpoint_every_eval or (_iter_id == total_iters - 1)):
-            save_train_state(config, train_state)
+        completed_epochs += config.stage_epochs
 
     # finalize
     if dist.is_initialized():


### PR DESCRIPTION
## Summary
- Ignore left padding when building multiplication datasets by marking leading zeros as PAD tokens
- Allow data loader to filter examples by operand length and expose a max-digit curriculum schedule in pretraining
- Iterate training across curriculum stages with stage-specific dataloaders

## Testing
- `python -m py_compile dataset/build_mult_digit_mul_dataset.py puzzle_dataset.py pretrain.py`
- `python dataset/build_mult_digit_mul_dataset.py --output-dir tmp_data --num-train 2 --num-test 1 --max-digits 5 --print-samples 1`


------
https://chatgpt.com/codex/tasks/task_e_68959a91833483268ff2481f3dbb1bac