### PR TITLE
Add configurable dropout option

### DIFF
--- a/config/arch/hrm_v1.yaml
+++ b/config/arch/hrm_v1.yaml
@@ -19,3 +19,4 @@ expansion: 4
 puzzle_emb_ndim: ${.hidden_size}
 
 pos_encodings: rope
+dropout: 0.1

--- a/models/hrm/hrm_act_v1.py
+++ b/models/hrm/hrm_act_v1.py
@@ -46,6 +46,7 @@ class HierarchicalReasoningModel_ACTV1Config(BaseModel):
     expansion: float
     num_heads: int
     pos_encodings: str
+    dropout: float = 0.0
 
     rms_norm_eps: float = 1e-5
     rope_theta: float = 10000.0
@@ -66,11 +67,13 @@ class HierarchicalReasoningModel_ACTV1Block(nn.Module):
             head_dim=config.hidden_size // config.num_heads,
             num_heads=config.num_heads,
             num_key_value_heads=config.num_heads,
-            causal=False
+            causal=False,
+            dropout=config.dropout
         )
         self.mlp = SwiGLU(
             hidden_size=config.hidden_size,
             expansion=config.expansion,
+            dropout=config.dropout
         )
         self.norm_eps = config.rms_norm_eps
 

--- a/pretrain.py
+++ b/pretrain.py
@@ -35,6 +35,7 @@ class ArchConfig(pydantic.BaseModel):
 
     name: str
     loss: LossConfig
+    dropout: float = 0.0
 
 
 class PretrainConfig(pydantic.BaseModel):
@@ -115,6 +116,7 @@ def create_model(config: PretrainConfig, train_metadata: PuzzleDatasetMetadata, 
     model_cfg = dict(
         **config.arch.__pydantic_extra__,  # type: ignore
 
+        dropout=config.arch.dropout,
         batch_size=config.global_batch_size // world_size,
 
         vocab_size=train_metadata.vocab_size,


### PR DESCRIPTION
## Summary
- add configurable dropout to Attention and SwiGLU layers
- expose `dropout` parameter in HRM model config and architecture YAML
- propagate dropout setting through `pretrain.py`

## Testing
- `python -m py_compile models/layers.py models/hrm/hrm_act_v1.py pretrain.py`

------
https://chatgpt.com/codex/tasks/task_e_6899b1fe6e548326bea3ca0183ad3c78