### PR TITLE
Add optional pretrained model loading for continued training

### DIFF
--- a/config/cfg_pretrain.yaml
+++ b/config/cfg_pretrain.yaml
@@ -31,3 +31,6 @@ puzzle_emb_weight_decay: 0.1
 puzzle_emb_lr: 1e-2
 max_digits_schedule: [2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]  # digits per stage
 stage_epochs: 100
+
+# Optional path to initialize model weights from a pretrained checkpoint
+pretrained_path: null

--- a/pretrain.py
+++ b/pretrain.py
@@ -66,6 +66,9 @@ class PretrainConfig(pydantic.BaseModel):
     run_name: Optional[str] = None
     checkpoint_path: Optional[str] = None
 
+    # Optional path to load a pretrained model before training
+    pretrained_path: Optional[str] = None
+
     # Extras
     seed: int = 0
     checkpoint_every_eval: bool = False
@@ -133,6 +136,14 @@ def create_model(config: PretrainConfig, train_metadata: PuzzleDatasetMetadata, 
     with torch.device("cuda"):
         model: nn.Module = model_cls(model_cfg)
         model = loss_head_cls(model, **config.arch.loss.__pydantic_extra__)  # type: ignore
+
+        # Optionally initialize from a pretrained checkpoint
+        if config.pretrained_path is not None:
+            state = torch.load(config.pretrained_path, map_location="cpu")
+            missing, unexpected = model.load_state_dict(state, strict=False)
+            if missing or unexpected:
+                print(f"Warning: missing keys {missing}, unexpected keys {unexpected} when loading pretrained state")
+
         if "DISABLE_COMPILE" not in os.environ:
             model = torch.compile(model, dynamic=False)  # type: ignore
 


### PR DESCRIPTION
## Summary
- add `pretrained_path` config option to load an existing model state
- load state dict before compiling model when path is provided
- document optional checkpoint path in default config

## Testing
- `python -m py_compile pretrain.py`


------
https://chatgpt.com/codex/tasks/task_e_689b2a05d87883269d8bf56e37d6d306