### PR TITLE
Add causal attention flag for HRM models

### DIFF
--- a/config/arch/hrm_v1.yaml
+++ b/config/arch/hrm_v1.yaml
@@ -20,3 +20,4 @@ puzzle_emb_ndim: ${.hidden_size}
 
 pos_encodings: rope
 dropout: 0.1
+causal: true

--- a/models/hrm/hrm_act_v1.py
+++ b/models/hrm/hrm_act_v1.py
@@ -47,6 +47,7 @@ class HierarchicalReasoningModel_ACTV1Config(BaseModel):
     num_heads: int
     pos_encodings: str
     dropout: float = 0.0
+    causal: bool = False
 
     rms_norm_eps: float = 1e-5
     rope_theta: float = 10000.0
@@ -67,7 +68,7 @@ class HierarchicalReasoningModel_ACTV1Block(nn.Module):
             head_dim=config.hidden_size // config.num_heads,
             num_heads=config.num_heads,
             num_key_value_heads=config.num_heads,
-            causal=False,
+            causal=config.causal,
             dropout=config.dropout
         )
         self.mlp = SwiGLU(

--- a/pretrain.py
+++ b/pretrain.py
@@ -37,6 +37,7 @@ class ArchConfig(pydantic.BaseModel):
     name: str
     loss: LossConfig
     dropout: float = 0.0
+    causal: bool = False
 
 
 class PretrainConfig(pydantic.BaseModel):
@@ -123,7 +124,7 @@ def create_model(config: PretrainConfig, train_metadata: PuzzleDatasetMetadata, 
         vocab_size=train_metadata.vocab_size,
         seq_len=train_metadata.seq_len,
         num_puzzle_identifiers=train_metadata.num_puzzle_identifiers,
-        causal=False  # Non-autoregressive
+        causal=config.arch.causal
     )
 
     # Instantiate model with loss head


### PR DESCRIPTION
## Summary
- add `causal` flag to HierarchicalReasoningModel_ACTV1 config
- wire causal flag through blocks and pretraining config
- enable causal attention in hrm_v1 architecture

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a2d60d2eb48326a92a48c2f3e226c0