### PR TITLE
Enable autoregressive modeling

### DIFF
--- a/models/hrm/hrm_act_v1.py
+++ b/models/hrm/hrm_act_v1.py
@@ -46,6 +46,7 @@ class HierarchicalReasoningModel_ACTV1Config(BaseModel):
     expansion: float
     num_heads: int
     pos_encodings: str
+    causal: bool = False
     dropout: float = 0.0
 
     rms_norm_eps: float = 1e-5
@@ -67,7 +68,7 @@ class HierarchicalReasoningModel_ACTV1Block(nn.Module):
             head_dim=config.hidden_size // config.num_heads,
             num_heads=config.num_heads,
             num_key_value_heads=config.num_heads,
-            causal=False,
+            causal=config.causal,
             dropout=config.dropout
         )
         self.mlp = SwiGLU(

--- a/pretrain.py
+++ b/pretrain.py
@@ -123,7 +123,7 @@ def create_model(config: PretrainConfig, train_metadata: PuzzleDatasetMetadata, 
         vocab_size=train_metadata.vocab_size,
         seq_len=train_metadata.seq_len,
         num_puzzle_identifiers=train_metadata.num_puzzle_identifiers,
-        causal=False  # Non-autoregressive
+        causal=True  # Autoregressive
     )
 
     # Instantiate model with loss head


### PR DESCRIPTION
## Summary
- Add `causal` flag to HRM configuration and wire it into attention blocks.
- Enable autoregressive training in `pretrain.py` by setting the model to causal mode.

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a461ae33d88326beccd865e0f879c8