### PR TITLE
Reintroduce non-autoregressive training with accuracy-based curriculum

### DIFF
--- a/config/cfg_pretrain.yaml
+++ b/config/cfg_pretrain.yaml
@@ -30,4 +30,4 @@ puzzle_emb_weight_decay: 0.1
 # Hyperparams - Puzzle embeddings training
 puzzle_emb_lr: 1e-2
 max_digits_schedule: [2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]  # digits per stage
-stage_epochs: 100
+stage_accuracy: 0.99  # accuracy threshold to move to next digit


### PR DESCRIPTION
## Summary
- disable causal masking to return to non-autoregressive training
- add `stage_accuracy` option and scheduler that advances when accuracy threshold is met
- expose accuracy threshold in `cfg_pretrain.yaml`
- drop stage epoch limit so curriculum advances solely on accuracy

## Testing
- `python -m py_compile pretrain.py`
- `python - <<'PY'
import yaml,sys
yaml.safe_load(open('config/cfg_pretrain.yaml'))
print('ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a582424ea88326ac84b356d09b1635